### PR TITLE
Skip nil values in response

### DIFF
--- a/lib/survey_gizmo/resource.rb
+++ b/lib/survey_gizmo/resource.rb
@@ -292,7 +292,7 @@ module SurveyGizmo
         # Handle really crappy [] notation in SG API, so far just in SurveyResponse
         (@_data.is_a?(Array) ? @_data : [@_data]).each do |data_item|
           data_item.keys.grep(/^\[/).each do |key|
-            next unless data_item[key].length > 0
+            next unless data_item[key].nil? || data_item[key].length > 0
 
             parent = find_attribute_parent(key)
             data_item[parent] = {} unless data_item[parent]


### PR DESCRIPTION
We received surveygizmo responses with the field `"[variable(\"STANDARD_USERAGENT\")]"=>nil`, making the gem raise.

This pull requests skips nil parameters as well as empty parameters
