### PR TITLE
renamed survey.rb variable...

### DIFF
--- a/lib/survey_gizmo/api/survey.rb
+++ b/lib/survey_gizmo/api/survey.rb
@@ -7,7 +7,7 @@ module SurveyGizmo; module API
     #   @return [$2]
     attribute :id,             Integer
     attribute :team,           Integer
-    attribute :_type,          String
+    attribute :type,          String
     attribute :_subtype,       String
     attribute :status,         String
     attribute :forward_only,   Boolean

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -47,7 +47,7 @@ describe "Survey Gizmo Resource" do
   end
 
   describe SurveyGizmo::API::Survey do
-    let(:create_attributes){ {:title => 'Spec', :_type => 'survey', :status => 'In Design'} }
+    let(:create_attributes){ {:title => 'Spec', :type => 'survey', :status => 'In Design'} }
     let(:get_attributes)   { create_attributes.merge(:id => 1234) }
     let(:update_attributes){ {:title => 'Updated'} }
     let(:first_params){ {:id => 1234} }


### PR DESCRIPTION
... to allow creation of surveys (previously returned errors).

In reference to [this](https://github.com/RipTheJacker/survey-gizmo-ruby/issues/13) issue. I renamed the _type attribute to just type, and the related spec. I can now create a survey, where before it returned an error (see link).
