### PR TITLE
Switch from travis CI to Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,4 @@ jobs:
       run: bundle install --jobs 4 --retry 3
 
     - name: RSpec
-      run: bin/rake spec
+      run: bundle exec rspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: on ruby ${{matrix.ruby}}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [2.4, 2.5, 2.6, 2.7, 3.0, head]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{matrix.ruby}}
+
+    - name: Install dependencies
+      run: bundle install --jobs 4 --retry 3
+
+    - name: RSpec
+      run: bin/rake spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: ruby
-dist: bionic
-rvm:
-  - 2.4.9
-  - 2.5.7
-  - 2.6.5
-  - 2.7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Versions
 
+## 8.0.0 (unreleased)
+* Switch CI from Travis to Github actions
+
 ## 7.1.1
 * Add missing `subtype` parameter to `Campain` required at creation
 * Fix use of deprecated Faraday error class (#110)


### PR DESCRIPTION
Travis CI isn't working very well for open source projects anymore, lets switch to github actions