### PR TITLE
Better: Use Alchemer API URLs by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Versions
 
-## 8.0.0
+## 8.0.0 (unreleased)
 * BREAKING CHANGE: Switch from the old Survey Gizmo API URLs (`restapi.surveygizmo.com` and `restapi.surveygizmo.eu`) to the new Alchemer API URLs (`api.alchemer.com` and `api.alchemer.eu`)
 * Fix ruby 3.2 build
 * Fix ruby 2.7 build and compatibility with activesupport >= 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Versions
 
-## 8.0.0 (unreleased)
+## 8.0.0
+* BREAKING CHANGE: Switch from the old Survey Gizmo API URLs (`restapi.surveygizmo.com` and `restapi.surveygizmo.eu`) to the new Alchemer API URLs (`api.alchemer.com` and `api.alchemer.eu`)
 * Fix ruby 3.2 build
 * Fix ruby 2.7 build and compatibility with activesupport >= 7
 * Switch CI from Travis to Github actions

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ SurveyGizmo.configure do |config|
   # Optional - Set if you need to hit a different region (e.g. the .eu domain)
   config.region = :eu
 
+  # Optional - Set if you need to hit a different api (e.g. the api.alchemer.{com,eu} api)
+  config.api = :alchemer
+
   # Optional - Defaults to 50, maximum 500. Setting too high may cause SurveyGizmo to start throwing timeouts.
   config.results_per_page = 100
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ SurveyGizmo.configure do |config|
   # Optional - Set if you need to hit a different region (e.g. the .eu domain)
   config.region = :eu
 
-
   # Optional - Defaults to 50, maximum 500. Setting too high may cause SurveyGizmo to start throwing timeouts.
   config.results_per_page = 100
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # Survey Gizmo (ruby)
 
-[![Build Status](https://travis-ci.org/jarthod/survey-gizmo-ruby.svg?branch=master)](https://travis-ci.org/jarthod/survey-gizmo-ruby)
+Integrate with the [Alchemer API](https://apihelp.alchemer.com/help) using an ActiveModel style interface.
 
-Integrate with the [Survey Gizmo API](https://apihelp.surveygizmo.com/help) using an ActiveModel style interface.
-
-Currently supports SurveyGizmo API **v4** (default) and **v3**.
+Currently supports Alchemer API **v4** (default) and **v3**.
 
 ## Version History
 
@@ -36,8 +34,6 @@ SurveyGizmo.configure do |config|
   # Optional - Set if you need to hit a different region (e.g. the .eu domain)
   config.region = :eu
 
-  # Optional - Set if you need to hit a different api (e.g. the api.alchemer.{com,eu} api)
-  config.api = :alchemer
 
   # Optional - Defaults to 50, maximum 500. Setting too high may cause SurveyGizmo to start throwing timeouts.
   config.results_per_page = 100

--- a/lib/survey_gizmo/configuration.rb
+++ b/lib/survey_gizmo/configuration.rb
@@ -41,28 +41,22 @@ module SurveyGizmo
   end
 
   class Configuration
-    DEFAULT_API = :surveygizmo
-    DEFAULT_API_VERSION = 'v4'.freeze
+    DEFAULT_API_VERSION = 'v4'
     DEFAULT_RESULTS_PER_PAGE = 50
     DEFAULT_TIMEOUT_SECONDS = 300
     DEFAULT_REGION = :us
-    DEFAULT_LOCALE = 'English'.freeze
-
-    APIS_INFO = {
-      surveygizmo: 'restapi.surveygizmo',
-      alchemer: 'api.alchemer'
-    }.freeze
+    DEFAULT_LOCALE = 'English'
 
     REGION_INFO = {
       us: {
-        tld: 'com',
+        url: 'https://api.alchemer.com',
         locale: 'Eastern Time (US & Canada)'
       },
       eu: {
-        tld: 'eu',
+        url: 'https://api.alchemer.eu',
         locale: 'UTC'
       }
-    }.freeze
+    }
 
     DEFAULT_RETRIABLE_PARAMS = {
       base_interval: 60,
@@ -79,7 +73,7 @@ module SurveyGizmo
       on_retry: Proc.new do |exception, tries|
         SurveyGizmo.configuration.logger.warn("Retrying after #{exception.class}: #{tries} attempts.")
       end
-    }.freeze
+    }
 
     attr_accessor :api_token
     attr_accessor :api_token_secret
@@ -106,7 +100,6 @@ module SurveyGizmo
       @timeout_seconds = DEFAULT_TIMEOUT_SECONDS
       @retriable_params = DEFAULT_RETRIABLE_PARAMS
       @locale = DEFAULT_LOCALE
-      self.api = DEFAULT_API
       self.region = DEFAULT_REGION
 
       @logger = SurveyGizmo::Logger.new(STDOUT)
@@ -117,24 +110,8 @@ module SurveyGizmo
       region_infos = REGION_INFO[region]
       raise ArgumentError.new("Unknown region: #{region}") unless region_infos
 
-      @api_tld = region_infos[:tld]
+      @api_url = region_infos[:url]
       @api_time_zone = region_infos[:locale]
-
-      build_api_url
-    end
-
-    def api=(api)
-      raise ArgumentError.new("Unknown api: #{api}") unless APIS_INFO.keys.include?(api)
-
-      @api = APIS_INFO[api]
-
-      build_api_url
-    end
-
-    private
-
-    def build_api_url
-      @api_url = "https://#{@api}.#{@api_tld}"
     end
   end
 end

--- a/lib/survey_gizmo/configuration.rb
+++ b/lib/survey_gizmo/configuration.rb
@@ -41,22 +41,28 @@ module SurveyGizmo
   end
 
   class Configuration
-    DEFAULT_API_VERSION = 'v4'
+    DEFAULT_API = :surveygizmo
+    DEFAULT_API_VERSION = 'v4'.freeze
     DEFAULT_RESULTS_PER_PAGE = 50
     DEFAULT_TIMEOUT_SECONDS = 300
     DEFAULT_REGION = :us
-    DEFAULT_LOCALE = 'English'
+    DEFAULT_LOCALE = 'English'.freeze
+
+    APIS_INFO = {
+      surveygizmo: 'restapi.surveygizmo',
+      alchemer: 'api.alchemer'
+    }.freeze
 
     REGION_INFO = {
       us: {
-        url: 'https://restapi.surveygizmo.com',
+        tld: 'com',
         locale: 'Eastern Time (US & Canada)'
       },
       eu: {
-        url: 'https://restapi.surveygizmo.eu',
+        tld: 'eu',
         locale: 'UTC'
       }
-    }
+    }.freeze
 
     DEFAULT_RETRIABLE_PARAMS = {
       base_interval: 60,
@@ -73,7 +79,7 @@ module SurveyGizmo
       on_retry: Proc.new do |exception, tries|
         SurveyGizmo.configuration.logger.warn("Retrying after #{exception.class}: #{tries} attempts.")
       end
-    }
+    }.freeze
 
     attr_accessor :api_token
     attr_accessor :api_token_secret
@@ -100,6 +106,7 @@ module SurveyGizmo
       @timeout_seconds = DEFAULT_TIMEOUT_SECONDS
       @retriable_params = DEFAULT_RETRIABLE_PARAMS
       @locale = DEFAULT_LOCALE
+      self.api = DEFAULT_API
       self.region = DEFAULT_REGION
 
       @logger = SurveyGizmo::Logger.new(STDOUT)
@@ -110,8 +117,24 @@ module SurveyGizmo
       region_infos = REGION_INFO[region]
       raise ArgumentError.new("Unknown region: #{region}") unless region_infos
 
-      @api_url = region_infos[:url]
+      @api_tld = region_infos[:tld]
       @api_time_zone = region_infos[:locale]
+
+      build_api_url
+    end
+
+    def api=(api)
+      raise ArgumentError.new("Unknown api: #{api}") unless APIS_INFO.keys.include?(api)
+
+      @api = APIS_INFO[api]
+
+      build_api_url
+    end
+
+    private
+
+    def build_api_url
+      @api_url = "https://#{@api}.#{@api_tld}"
     end
   end
 end

--- a/lib/survey_gizmo/version.rb
+++ b/lib/survey_gizmo/version.rb
@@ -1,3 +1,3 @@
 module SurveyGizmo
-  VERSION = '7.1.1'
+  VERSION = '7.1.2'
 end

--- a/lib/survey_gizmo/version.rb
+++ b/lib/survey_gizmo/version.rb
@@ -1,3 +1,3 @@
 module SurveyGizmo
-  VERSION = '7.1.2'
+  VERSION = '8.0.0'
 end

--- a/lib/survey_gizmo/version.rb
+++ b/lib/survey_gizmo/version.rb
@@ -1,3 +1,3 @@
 module SurveyGizmo
-  VERSION = '8.0.0'
+  VERSION = '7.1.1'
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -151,4 +151,35 @@ describe SurveyGizmo::Configuration do
       expect(SurveyGizmo.configuration.locale).to eq('Italian')
     end
   end
+
+  describe '#api=' do
+    it 'should set surveygizmo by default' do
+      SurveyGizmo.configure
+      expect(SurveyGizmo.configuration.api_url).to eq('https://restapi.surveygizmo.com')
+    end
+
+    it 'should set surveygizmo api with :surveygizmo symbol specified' do
+      SurveyGizmo.configure do |config|
+        config.api = :surveygizmo
+      end
+
+      expect(SurveyGizmo.configuration.api_url).to eq('https://restapi.surveygizmo.com')
+    end
+
+    it 'should set alchemer api with :alchemer symbol specified' do
+      SurveyGizmo.configure do |config|
+        config.api = :alchemer
+      end
+
+      expect(SurveyGizmo.configuration.api_url).to eq('https://api.alchemer.com')
+    end
+
+    it 'should fail with an unavailable api' do
+      expect {
+        SurveyGizmo.configure do |config|
+          config.api = :google
+        end
+      }.to raise_error(ArgumentError, "Unknown api: google")
+    end
+  end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -128,6 +128,15 @@ describe SurveyGizmo::Configuration do
       expect(SurveyGizmo.configuration.api_time_zone).to eq('UTC')
     end
 
+    it 'can be combined with api change' do
+      SurveyGizmo.configure do |config|
+        config.api = :alchemer
+        config.region = :eu
+      end
+
+      expect(SurveyGizmo.configuration.api_url).to eq('https://api.alchemer.eu')
+    end
+
     it 'should fail with an unavailable region' do
       expect {
         SurveyGizmo.configure do |config|
@@ -153,7 +162,7 @@ describe SurveyGizmo::Configuration do
   end
 
   describe '#api=' do
-    it 'should set surveygizmo by default' do
+    it 'should set surveygizmo api by default' do
       SurveyGizmo.configure
       expect(SurveyGizmo.configuration.api_url).to eq('https://restapi.surveygizmo.com')
     end
@@ -172,6 +181,15 @@ describe SurveyGizmo::Configuration do
       end
 
       expect(SurveyGizmo.configuration.api_url).to eq('https://api.alchemer.com')
+    end
+
+    it 'can be combined with region change' do
+      SurveyGizmo.configure do |config|
+        config.api = :alchemer
+        config.region = :eu
+      end
+
+      expect(SurveyGizmo.configuration.api_url).to eq('https://api.alchemer.eu')
     end
 
     it 'should fail with an unavailable api' do

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -130,8 +130,8 @@ describe SurveyGizmo::Configuration do
 
     it 'can be combined with api change' do
       SurveyGizmo.configure do |config|
-        config.api = :alchemer
         config.region = :eu
+        config.api = :alchemer
       end
 
       expect(SurveyGizmo.configuration.api_url).to eq('https://api.alchemer.eu')

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -106,7 +106,7 @@ describe SurveyGizmo::Configuration do
   describe '#region=' do
     it 'should set US region by default' do
       SurveyGizmo.configure
-      expect(SurveyGizmo.configuration.api_url).to eq('https://restapi.surveygizmo.com')
+      expect(SurveyGizmo.configuration.api_url).to eq('https://api.alchemer.com')
       expect(SurveyGizmo.configuration.api_time_zone).to eq('Eastern Time (US & Canada)')
     end
 
@@ -115,7 +115,7 @@ describe SurveyGizmo::Configuration do
         config.region = :us
       end
 
-      expect(SurveyGizmo.configuration.api_url).to eq('https://restapi.surveygizmo.com')
+      expect(SurveyGizmo.configuration.api_url).to eq('https://api.alchemer.com')
       expect(SurveyGizmo.configuration.api_time_zone).to eq('Eastern Time (US & Canada)')
     end
 
@@ -124,17 +124,8 @@ describe SurveyGizmo::Configuration do
         config.region = :eu
       end
 
-      expect(SurveyGizmo.configuration.api_url).to eq('https://restapi.surveygizmo.eu')
-      expect(SurveyGizmo.configuration.api_time_zone).to eq('UTC')
-    end
-
-    it 'can be combined with api change' do
-      SurveyGizmo.configure do |config|
-        config.region = :eu
-        config.api = :alchemer
-      end
-
       expect(SurveyGizmo.configuration.api_url).to eq('https://api.alchemer.eu')
+      expect(SurveyGizmo.configuration.api_time_zone).to eq('UTC')
     end
 
     it 'should fail with an unavailable region' do
@@ -158,46 +149,6 @@ describe SurveyGizmo::Configuration do
       end
 
       expect(SurveyGizmo.configuration.locale).to eq('Italian')
-    end
-  end
-
-  describe '#api=' do
-    it 'should set surveygizmo api by default' do
-      SurveyGizmo.configure
-      expect(SurveyGizmo.configuration.api_url).to eq('https://restapi.surveygizmo.com')
-    end
-
-    it 'should set surveygizmo api with :surveygizmo symbol specified' do
-      SurveyGizmo.configure do |config|
-        config.api = :surveygizmo
-      end
-
-      expect(SurveyGizmo.configuration.api_url).to eq('https://restapi.surveygizmo.com')
-    end
-
-    it 'should set alchemer api with :alchemer symbol specified' do
-      SurveyGizmo.configure do |config|
-        config.api = :alchemer
-      end
-
-      expect(SurveyGizmo.configuration.api_url).to eq('https://api.alchemer.com')
-    end
-
-    it 'can be combined with region change' do
-      SurveyGizmo.configure do |config|
-        config.api = :alchemer
-        config.region = :eu
-      end
-
-      expect(SurveyGizmo.configuration.api_url).to eq('https://api.alchemer.eu')
-    end
-
-    it 'should fail with an unavailable api' do
-      expect {
-        SurveyGizmo.configure do |config|
-          config.api = :google
-        end
-      }.to raise_error(ArgumentError, "Unknown api: google")
     end
   end
 end


### PR DESCRIPTION
The goal of this PR is to switch to the Alchemer API URLs