### PR TITLE
Add access to title locales for models using multilingual title concern

### DIFF
--- a/lib/survey_gizmo/multilingual_title.rb
+++ b/lib/survey_gizmo/multilingual_title.rb
@@ -5,9 +5,12 @@ module SurveyGizmo
 
     included do
       attribute :title, Hash
+      # Using attr_accessor because it's not an API field
+      attr_accessor :title_ml
     end
 
     def title=(val)
+      self.title_ml = val.is_a?(Hash) ? val : { SurveyGizmo.configuration.locale => val }
       super(val.is_a?(Hash) ? val[SurveyGizmo.configuration.locale] : val)
     end
   end

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -94,6 +94,7 @@ describe 'Survey Gizmo Resource' do
 
     it_should_behave_like 'an API object'
     it_should_behave_like 'an object with errors'
+    it_should_behave_like 'a MultilingualTitle object'
 
     it 'should handle the title hash returned from the API' do
       expect(described_class.new('title' => {'English' => 'Some title'}).title).to eq('Some title')
@@ -204,6 +205,7 @@ describe 'Survey Gizmo Resource' do
 
     it_should_behave_like 'an API object'
     it_should_behave_like 'an object with errors'
+    it_should_behave_like 'a MultilingualTitle object'
   end
 
   describe SurveyGizmo::API::Page do
@@ -219,6 +221,7 @@ describe 'Survey Gizmo Resource' do
 
     it_should_behave_like 'an API object'
     it_should_behave_like 'an object with errors'
+    it_should_behave_like 'a MultilingualTitle object'
   end
 
   describe SurveyGizmo::API::Response do

--- a/spec/support/spec_shared_multilingual_title.rb
+++ b/spec/support/spec_shared_multilingual_title.rb
@@ -1,0 +1,70 @@
+shared_examples_for 'a MultilingualTitle object' do
+  let(:object) { described_class.new }
+
+  describe 'title=' do
+    before(:each) do
+      object.title = payload
+    end
+
+    context 'with a Hash' do
+      let(:payload) { { 'English' => 'Title', 'French' => 'Titre' } }
+
+      it 'uses the raw value to set title_ml property' do
+        expect(object.title_ml).to eq(payload)
+      end
+
+      it 'sets title to the right value' do
+        expect(object.title).to eq('Title')
+      end
+    end
+
+    context 'with a String' do
+      let(:payload) { 'Title' }
+
+      it 'creates a fallback hash to set title_ml property' do
+        expect(object.title_ml).to eq('English' => payload)
+      end
+
+      it 'sets title to the right value' do
+        expect(object.title).to eq(payload)
+      end
+    end
+
+    context 'with a different locale' do
+      before(:each) do
+        SurveyGizmo.configure do |config|
+          config.locale = 'French'
+        end
+        object.title = payload
+      end
+
+      after(:each) do
+        SurveyGizmo.reset!
+      end
+
+      context 'with a Hash' do
+        let(:payload) { { 'English' => 'Title', 'French' => 'Titre' } }
+
+        it 'uses the raw value to set title_ml property' do
+          expect(object.title_ml).to eq(payload)
+        end
+
+        it 'sets title to the right value' do
+          expect(object.title).to eq('Titre')
+        end
+      end
+
+      context 'with a String' do
+        let(:payload) { 'Titre' }
+
+        it 'creates a valid fallback hash to set title_ml property' do
+          expect(object.title_ml).to eq('French' => payload)
+        end
+
+        it 'sets title to the right value' do
+          expect(object.title).to eq(payload)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- adds a title_ml property to SurveyGizmo::MultilingualTitle concern to avoid losing localization information
- adds shared examples for that concern
- uses the shared examples for resource classes that include the concern